### PR TITLE
Bluetooth: Discovery Manager: Zero out instance struct

### DIFF
--- a/subsys/bluetooth/gatt_dm.c
+++ b/subsys/bluetooth/gatt_dm.c
@@ -74,7 +74,7 @@ struct bt_gatt_dm {
 };
 
 /* Currently only one instance is supported */
-static struct bt_gatt_dm bt_gatt_dm_inst;
+static struct bt_gatt_dm bt_gatt_dm_inst = { 0 };
 
 /* Returns pointer to newly allocated space in a dm->data_chunk */
 static void *user_data_alloc(struct bt_gatt_dm *dm,


### PR DESCRIPTION
The struct 'bt_gatt_dm_inst' is never set to 0. This results in the STATE_ATTRS_LOCKED flag to be set randomly, resulting in invalid discovery states. This commit initializes this struct to 0.